### PR TITLE
fixed turbolinks issue

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,7 +27,10 @@ gem 'turbolinks'
 gem 'jbuilder', '~> 2.0'
 # bundle exec rake doc:rails generates the API under doc/api.
 gem 'sdoc', '~> 0.4.0', group: :doc
-
+# make turbolinks compatible with jquery
+gem 'jquery-turbolinks'
+gem 'execjs'
+gem 'therubyracer'
 # Use ActiveModel has_secure_password
 gem 'bcrypt'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,8 +109,12 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    jquery-turbolinks (2.1.0)
+      railties (>= 3.1.0)
+      turbolinks
     json (1.8.6)
     jwt (1.5.6)
+    libv8 (3.16.14.19)
     little-plugger (1.1.4)
     logging (2.2.2)
       little-plugger (~> 1.1)
@@ -169,6 +173,7 @@ GEM
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
     rdoc (4.3.0)
+    ref (2.0.0)
     representable (3.0.4)
       declarative (< 0.1.0)
       declarative-option (< 0.2.0)
@@ -200,6 +205,9 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
+    therubyracer (0.12.3)
+      libv8 (~> 3.16.14.15)
+      ref
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
@@ -232,15 +240,18 @@ DEPENDENCIES
   bootstrap (~> 4.0.0.beta2.1)
   byebug
   coffee-rails (~> 4.1.0)
+  execjs
   font-awesome-sass
   gmaps4rails
   google-cloud-storage
   jbuilder (~> 2.0)
   jquery-rails
+  jquery-turbolinks
   pg
   rails (= 4.2.8)
   sass-rails (~> 5.0)
   sdoc (~> 0.4.0)
+  therubyracer
   toastr-rails
   turbolinks
   tzinfo-data

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -21,3 +21,4 @@
 //= require bootstrap
 //= require jquery-sidebar
 //= require_tree .
+//= require jquery.turbolinks


### PR DESCRIPTION
I had to install execjs and therubyracer gems as I had so broken the app that I was getting an 'execjs:runtime' error. But this fixes our turbolinks issue.